### PR TITLE
chore: version-lock faye-redis to 2.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 , "version"         : "0.2.0"
 , "engines"         : {"node": ">=0.4.0"}
 , "main"            : "./faye-redis"
-, "dependencies"    : {"redis": ""}
+, "dependencies"    : {"redis": "2.8.0"}
 , "devDependencies" : {"jstest": ""}
 
 , "scripts"         : {"test": "node spec/runner.js"}


### PR DESCRIPTION
- we were getting whatever version of redis happened to be the latest when we did a build
- we have been using 2.8.0 for several months now